### PR TITLE
Refactor/consumergroup

### DIFF
--- a/config.go
+++ b/config.go
@@ -26,8 +26,6 @@ type Config struct {
 	OffsetAutoCommitInterval time.Duration
 	// Where to fetch messages when offset was not found, default is newest
 	OffsetAutoReset int64
-	// Claim the partition util ClaimPartitionRetry retires
-	ClaimPartitionRetry int
 	// Retry interval when fail to clain the partition
 	ClaimPartitionRetryInterval time.Duration
 }
@@ -40,7 +38,6 @@ func NewConfig() *Config {
 	config.OffsetAutoCommitEnable = true
 	config.OffsetAutoCommitInterval = 10 * time.Second
 	config.OffsetAutoReset = sarama.OffsetNewest
-	config.ClaimPartitionRetry = 5
 	config.ClaimPartitionRetryInterval = 3 * time.Second
 	return config
 }

--- a/consumer_group.go
+++ b/consumer_group.go
@@ -275,7 +275,6 @@ func (cg *ConsumerGroup) claimPartition(topic string, partition int32) error {
 }
 
 func (cg *ConsumerGroup) consumePartition(topic string, partition int32) {
-	var consumer sarama.PartitionConsumer
 	var mutex sync.Mutex
 	var wg sync.WaitGroup
 
@@ -308,17 +307,16 @@ func (cg *ConsumerGroup) consumePartition(topic string, partition int32) {
 	}
 	cg.logger.Debugf("Get topic[%s] partition[%d] offset[%d] from offset storage", topic, partition, nextOffset)
 
-	consumer, err = cg.getPartitionConsumer(topic, partition, nextOffset)
+	consumer, err := cg.getPartitionConsumer(topic, partition, nextOffset)
 	if err != nil {
 		cg.logger.Errorf("Failed to get topic[%s] partition[%d] consumer, err %s", topic, partition, err)
 		cg.ExitGroup()
 		return
 	}
-	cg.logger.Infof("Topic[%s] partition[%d] Consumer has started", topic, partition)
 	defer consumer.Close()
+	cg.logger.Infof("Topic[%s] partition[%d] Consumer has started", topic, partition)
 
 	prevCommitOffset := nextOffset
-
 	if cg.config.OffsetAutoCommitEnable {
 		wg.Add(1)
 		go func() {

--- a/consumer_group.go
+++ b/consumer_group.go
@@ -94,7 +94,6 @@ func (cg *ConsumerGroup) SetLogger(logger Logger) {
 // JoinGroup would register ConsumerGroup, and rebalance would be triggered.
 // ConsumerGroup computes the partitions which should be consumed by consumer's num, and start fetching message.
 func (cg *ConsumerGroup) JoinGroup() error {
-
 	// exit when failed to register the consumer
 	err := cg.storage.registerConsumer(cg.name, cg.id, nil)
 	if err != nil && err != zk.ErrNodeExists {
@@ -154,14 +153,12 @@ CONSUME_TOPIC_LOOP:
 			cg.ExitGroup()
 			return
 		}
-
 		wg.Add(1)
 		go func() {
 			defer cg.callRecover()
 			defer wg.Done()
 			cg.autoReconnect(cg.storage.(*zkGroupStorage).sessionTimeout / 3)
 		}()
-
 		for _, topic := range cg.topicList {
 			wg.Add(1)
 			go func(topic string) {
@@ -172,7 +169,6 @@ CONSUME_TOPIC_LOOP:
 		}
 
 		cg.state = cgStart
-
 		select {
 		case <-cg.rebalanceTrigger:
 			cg.logger.Info("Trigger rebalance")
@@ -195,10 +191,7 @@ CONSUME_TOPIC_LOOP:
 func (cg *ConsumerGroup) consumeTopic(topic string) {
 	var wg sync.WaitGroup
 	cg.logger.Infof("Start to consume topic[%s]", topic)
-
-	defer func() {
-		cg.logger.Infof("Stop to consume topic[%s]", topic)
-	}()
+	defer cg.logger.Infof("Stop to consume topic[%s]", topic)
 
 	partitions, err := cg.assignPartitions(topic)
 	if err != nil {
@@ -206,7 +199,6 @@ func (cg *ConsumerGroup) consumeTopic(topic string) {
 		return
 	}
 	cg.logger.Infof("Topic[%s] Partitions %v are assigned to this consumer", topic, partitions)
-
 	for _, partition := range partitions {
 		wg.Add(1)
 		cg.logger.Infof("Start to consume Topic[%s] partition[%d]", topic, partition)
@@ -376,7 +368,6 @@ CONSUME_PARTITION_LOOP:
 			}
 		}
 	}
-
 	cg.logger.Infof("Topic[%s] partition[%d] consumer was stopped", topic, partition)
 }
 
@@ -419,7 +410,6 @@ func (cg *ConsumerGroup) watchRebalance() error {
 	if err != nil {
 		return err
 	}
-
 	go func() {
 		defer cg.callRecover()
 		cg.logger.Info("Rebalance checker was started")
@@ -431,7 +421,6 @@ func (cg *ConsumerGroup) watchRebalance() error {
 		}
 		cg.logger.Info("Rebalance checker was exited")
 	}()
-
 	return nil
 }
 

--- a/consumer_group.go
+++ b/consumer_group.go
@@ -412,14 +412,14 @@ func (cg *ConsumerGroup) watchRebalance() error {
 	}
 	go func() {
 		defer cg.callRecover()
-		cg.logger.Info("Rebalance checker was started")
+		cg.logger.Info("Rebalance watcher routine was started")
 		select {
 		case <-consumerListChange:
-			cg.logger.Info("Trigger rebalance while consumers was changed")
 			cg.rebalanceOnce.Do(cg.triggerRebalance)
+			cg.logger.Info("Trigger rebalance while consumers was changed")
 		case <-cg.stopper:
 		}
-		cg.logger.Info("Rebalance checker was exited")
+		cg.logger.Info("Rebalance watcher routine was exited")
 	}()
 	return nil
 }

--- a/consumer_group.go
+++ b/consumer_group.go
@@ -425,7 +425,6 @@ func (cg *ConsumerGroup) watchRebalance() error {
 }
 
 func (cg *ConsumerGroup) assignPartitions(topic string) ([]int32, error) {
-	j := 0
 	partNum, err := cg.getPartitionNum(topic)
 	if err != nil || partNum == 0 {
 		return nil, err
@@ -440,11 +439,10 @@ func (cg *ConsumerGroup) assignPartitions(topic string) ([]int32, error) {
 	}
 	partitions := make([]int32, 0, partNum/consumerNum+1)
 	for i := 0; i < partNum; i++ {
-		id := consumerList[j%consumerNum]
+		id := consumerList[i%consumerNum]
 		if id == cg.id {
 			partitions = append(partitions, int32(i))
 		}
-		j++
 	}
 	return partitions, nil
 }

--- a/consumer_group.go
+++ b/consumer_group.go
@@ -129,6 +129,7 @@ func (cg *ConsumerGroup) callRecover() {
 func (cg *ConsumerGroup) consumeTopicList() {
 	var wg sync.WaitGroup
 
+	defer cg.callRecover()
 	defer func() {
 		cg.state = cgStopped
 		for _, topic := range cg.topicList {
@@ -140,8 +141,6 @@ func (cg *ConsumerGroup) consumeTopicList() {
 			cg.logger.Errorf("Failed to delete consumer from zookeeper, err %s", err)
 		}
 	}()
-
-	defer cg.callRecover()
 
 CONSUME_TOPIC_LOOP:
 	for {

--- a/consumer_group.go
+++ b/consumer_group.go
@@ -20,8 +20,8 @@ const (
 // ConsumerGroup consume message from Kafka with rebalancing supports
 type ConsumerGroup struct {
 	name           string
-	topicList      []string
 	storage        groupStorage
+	topicConsumers map[string]*topicConsumer
 	saramaConsumer sarama.Consumer
 
 	id               string
@@ -31,11 +31,8 @@ type ConsumerGroup struct {
 	stopOnce         *sync.Once
 	rebalanceOnce    *sync.Once
 
-	messageChans map[string]chan *sarama.ConsumerMessage
-	errorChans   map[string]chan *sarama.ConsumerError
-
-	logger *proxyLogger
 	config *Config
+	logger *proxyLogger
 }
 
 // NewConsumerGroup create the ConsumerGroup instance with config
@@ -53,24 +50,22 @@ func NewConsumerGroup(config *Config) (*ConsumerGroup, error) {
 	cg.config = config
 	cg.id = genConsumerID()
 	cg.name = config.GroupID
-	cg.topicList = config.TopicList
 	cg.stopOnce = new(sync.Once)
 	cg.stopper = make(chan struct{})
 	cg.rebalanceOnce = new(sync.Once)
 	cg.rebalanceTrigger = make(chan struct{})
+	prefix := fmt.Sprintf("[go-consumergroup %s]", cg.name)
+	cg.topicConsumers = make(map[string]*topicConsumer)
+	cg.logger = newProxyLogger(prefix, newDefaultLogger(infoLevel))
 	cg.storage = newZKGroupStorage(config.ZkList, config.ZkSessionTimeout)
-	cg.messageChans = make(map[string]chan *sarama.ConsumerMessage)
-	cg.errorChans = make(map[string]chan *sarama.ConsumerError)
-	for _, topic := range cg.topicList {
-		cg.messageChans[topic] = make(chan *sarama.ConsumerMessage)
-		cg.errorChans[topic] = make(chan *sarama.ConsumerError, config.ErrorChannelBufferSize)
-	}
+
 	err = cg.initSaramaConsumer()
 	if err != nil {
 		return nil, fmt.Errorf("init sarama consumer, as %s", err)
 	}
-	prefix := fmt.Sprintf("[go-consumergroup %s]", cg.name)
-	cg.logger = newProxyLogger(prefix, newDefaultLogger(infoLevel))
+	for _, topic := range config.TopicList {
+		cg.topicConsumers[topic] = newTopicConsumer(cg, topic)
+	}
 	return cg, nil
 }
 
@@ -99,7 +94,7 @@ func (cg *ConsumerGroup) JoinGroup() error {
 	if err != nil && err != zk.ErrNodeExists {
 		return err
 	}
-	go cg.consumeTopicList()
+	go cg.start()
 	return nil
 }
 
@@ -125,19 +120,19 @@ func (cg *ConsumerGroup) callRecover() {
 	}
 }
 
-func (cg *ConsumerGroup) consumeTopicList() {
+func (cg *ConsumerGroup) start() {
 	var wg sync.WaitGroup
 
 	defer cg.callRecover()
 	defer func() {
 		cg.state = cgStopped
-		for _, topic := range cg.topicList {
-			close(cg.messageChans[topic])
-			close(cg.errorChans[topic])
-		}
 		err := cg.storage.deleteConsumer(cg.name, cg.id)
 		if err != nil {
 			cg.logger.Errorf("Failed to delete consumer from zookeeper, err %s", err)
+		}
+		for _, tc := range cg.topicConsumers {
+			close(tc.messages)
+			close(tc.errors)
 		}
 	}()
 
@@ -159,16 +154,16 @@ CONSUME_TOPIC_LOOP:
 			defer wg.Done()
 			cg.autoReconnect(cg.storage.(*zkGroupStorage).sessionTimeout / 3)
 		}()
-		for _, topic := range cg.topicList {
+		for _, consumer := range cg.topicConsumers {
 			wg.Add(1)
-			go func(topic string) {
+			go func(tc *topicConsumer) {
 				defer cg.callRecover()
 				defer wg.Done()
-				cg.consumeTopic(topic)
-			}(topic)
+				tc.start()
+			}(consumer)
 		}
-
 		cg.state = cgStart
+
 		select {
 		case <-cg.rebalanceTrigger:
 			cg.logger.Info("Trigger rebalance")
@@ -180,36 +175,12 @@ CONSUME_TOPIC_LOOP:
 			cg.rebalanceTrigger = make(chan struct{})
 			continue CONSUME_TOPIC_LOOP
 		case <-cg.stopper: // triggered when ExitGroup() is called
-			cg.logger.Info("ConsumeGroup is stopping")
+			cg.logger.Info("ConsumerGroup is stopping")
 			wg.Wait()
 			cg.logger.Info("ConsumerGroup was stopped")
 			return
 		}
 	}
-}
-
-func (cg *ConsumerGroup) consumeTopic(topic string) {
-	var wg sync.WaitGroup
-	cg.logger.Infof("Start to consume topic[%s]", topic)
-	defer cg.logger.Infof("Stop to consume topic[%s]", topic)
-
-	partitions, err := cg.assignPartitions(topic)
-	if err != nil {
-		cg.logger.Errorf("Failed to assign partitions to topic[%s], err %s", topic, err)
-		return
-	}
-	cg.logger.Infof("Topic[%s] Partitions %v are assigned to this consumer", topic, partitions)
-	for _, partition := range partitions {
-		wg.Add(1)
-		cg.logger.Infof("Start to consume Topic[%s] partition[%d]", topic, partition)
-		go func(topic string, partition int32) {
-			defer cg.callRecover()
-			defer wg.Done()
-			cg.consumePartition(topic, partition)
-		}(topic, partition)
-	}
-
-	wg.Wait()
 }
 
 func (cg *ConsumerGroup) getPartitionConsumer(topic string, partition int32, nextOffset int64) (sarama.PartitionConsumer, error) {
@@ -226,177 +197,24 @@ func (cg *ConsumerGroup) getPartitionConsumer(topic string, partition int32, nex
 
 // GetMessages was used to get a unbuffered message's channel from specified topic
 func (cg *ConsumerGroup) GetMessages(topic string) (<-chan *sarama.ConsumerMessage, error) {
-	if cg.messageChans[topic] == nil {
-		return nil, errors.New("topic was not found")
+	if topicConsumer, ok := cg.topicConsumers[topic]; ok {
+		return topicConsumer.messages, nil
 	}
-	return cg.messageChans[topic], nil
+	return nil, errors.New("topic was not found")
 }
 
 // GetErrors was used to get a unbuffered error's channel from specified topic
 func (cg *ConsumerGroup) GetErrors(topic string) (<-chan *sarama.ConsumerError, error) {
-	if cg.errorChans[topic] == nil {
-		return nil, errors.New("topic was not found")
+	if topicConsumer, ok := cg.topicConsumers[topic]; ok {
+		return topicConsumer.errors, nil
 	}
-	return cg.errorChans[topic], nil
-}
-
-func (cg *ConsumerGroup) releasePartition(topic string, partition int32) error {
-	owner, err := cg.storage.getPartitionOwner(cg.name, topic, partition)
-	if err != nil {
-		return err
-	}
-	if cg.id == owner {
-		return cg.storage.releasePartition(cg.name, topic, partition)
-	}
-	return errors.New("partition wasn't ownered by this consumergroup")
-}
-
-func (cg *ConsumerGroup) claimPartition(topic string, partition int32) error {
-	retry := 0
-	timer := time.NewTimer(cg.config.ClaimPartitionRetryInterval)
-	defer timer.Stop()
-	for { // retry until claim success or receive the stop signal
-		err := cg.storage.claimPartition(cg.name, topic, partition, cg.id)
-		if err == nil {
-			return nil
-		}
-		if retry%3 == 0 {
-			cg.logger.Errorf("Failed to claim topic[%s] partition[%d] after %d retires, err %s",
-				topic, partition, retry, err)
-		}
-		select {
-		case <-timer.C:
-			retry++
-			timer.Reset(cg.config.ClaimPartitionRetryInterval)
-		case <-cg.stopper:
-			return errors.New("stop signal was received when claim partition")
-		}
-	}
-}
-
-func (cg *ConsumerGroup) consumePartition(topic string, partition int32) {
-	var mutex sync.Mutex
-	var wg sync.WaitGroup
-
-	err := cg.claimPartition(topic, partition)
-	if err != nil {
-		cg.logger.Errorf("Failed to claim topic[%s] partition[%d] and give up, err %s",
-			topic, partition, err)
-		cg.ExitGroup()
-		return
-	}
-	cg.logger.Errorf("Claim topic[%s] partition[%d] success", topic, partition)
-	defer func() {
-		err = cg.releasePartition(topic, partition)
-		if err != nil {
-			cg.logger.Errorf("Failed to release topic[%s] partition[%d], err %s",
-				topic, partition, err)
-		} else {
-			cg.logger.Errorf("Release topic[%s] partition[%d] success", topic, partition)
-		}
-	}()
-
-	nextOffset, err := cg.storage.getOffset(cg.name, topic, partition)
-	if err != nil {
-		cg.logger.Errorf("Failed to get topic[%s] partition[%d] offset, err %s", topic, partition, err)
-		cg.ExitGroup()
-		return
-	}
-	if nextOffset == -1 {
-		nextOffset = cg.config.OffsetAutoReset
-	}
-	cg.logger.Debugf("Get topic[%s] partition[%d] offset[%d] from offset storage", topic, partition, nextOffset)
-
-	consumer, err := cg.getPartitionConsumer(topic, partition, nextOffset)
-	if err != nil {
-		cg.logger.Errorf("Failed to get topic[%s] partition[%d] consumer, err %s", topic, partition, err)
-		cg.ExitGroup()
-		return
-	}
-	defer consumer.Close()
-	cg.logger.Infof("Topic[%s] partition[%d] Consumer has started", topic, partition)
-
-	prevCommitOffset := nextOffset
-	if cg.config.OffsetAutoCommitEnable {
-		wg.Add(1)
-		go func() {
-			defer cg.callRecover()
-			defer wg.Done()
-			timer := time.NewTimer(cg.config.OffsetAutoCommitInterval)
-			for {
-				select {
-				case <-cg.stopper:
-					return
-				case <-timer.C:
-					timer.Reset(cg.config.OffsetAutoCommitInterval)
-					mutex.Lock()
-					offset := nextOffset
-					mutex.Unlock()
-
-					if offset == prevCommitOffset {
-						break
-					}
-					err := cg.storage.commitOffset(cg.name, topic, partition, offset)
-					if err != nil {
-						cg.logger.Warnf("Failed to commit topic[%s] partition[%d] offset, err %s", topic, partition, err)
-					} else {
-						cg.logger.Debugf("Commit topic[%s] partition[%d] offset[%d] to storage", topic, partition, offset)
-						prevCommitOffset = offset
-					}
-				}
-			}
-		}()
-	}
-
-	messageChan := cg.messageChans[topic]
-	errorChan := cg.errorChans[topic]
-
-CONSUME_PARTITION_LOOP:
-	for {
-		select {
-		case <-cg.stopper:
-			break CONSUME_PARTITION_LOOP
-		case error1 := <-consumer.Errors():
-			errorChan <- error1
-		case message := <-consumer.Messages():
-			select {
-			case messageChan <- message:
-				mutex.Lock()
-				nextOffset = message.Offset + 1
-				mutex.Unlock()
-			case <-cg.stopper:
-				break CONSUME_PARTITION_LOOP
-			}
-		}
-	}
-
-	wg.Wait()
-
-	if cg.config.OffsetAutoCommitEnable {
-		if nextOffset != prevCommitOffset {
-			err = cg.storage.commitOffset(cg.name, topic, partition, nextOffset)
-			if err != nil {
-				cg.logger.Errorf("Failed to Commit topic[%s] partition[%d] offset[%d], err %s", topic, partition, nextOffset, err)
-			} else {
-				cg.logger.Debugf("Commit topic[%s] partition[%d] offset[%d] to storage", topic, partition, nextOffset)
-			}
-		}
-	}
-	cg.logger.Infof("Topic[%s] partition[%d] consumer was stopped", topic, partition)
-}
-
-func (cg *ConsumerGroup) getPartitionNum(topic string) (int, error) {
-	partitions, err := cg.saramaConsumer.Partitions(topic)
-	if err != nil {
-		return 0, err
-	}
-	return len(partitions), nil
+	return nil, errors.New("topic was not found")
 }
 
 func (cg *ConsumerGroup) autoReconnect(interval time.Duration) {
 	timer := time.NewTimer(interval)
-	cg.logger.Info("The auto reconnect consumer goroutine was started")
-	defer cg.logger.Info("The auto reconnect consumer goroutine was stopped")
+	cg.logger.Info("The auto-reconnect consumer thread was started")
+	defer cg.logger.Info("The auto-reconnect consumer thread was stopped")
 	for {
 		select {
 		case <-cg.stopper:
@@ -426,39 +244,16 @@ func (cg *ConsumerGroup) watchRebalance() error {
 	}
 	go func() {
 		defer cg.callRecover()
-		cg.logger.Info("Rebalance watcher routine was started")
+		cg.logger.Info("Rebalance watcher thread was started")
 		select {
 		case <-consumerListChange:
 			cg.rebalanceOnce.Do(cg.triggerRebalance)
 			cg.logger.Info("Trigger rebalance while consumers was changed")
 		case <-cg.stopper:
 		}
-		cg.logger.Info("Rebalance watcher routine was exited")
+		cg.logger.Info("Rebalance watcher thread was exited")
 	}()
 	return nil
-}
-
-func (cg *ConsumerGroup) assignPartitions(topic string) ([]int32, error) {
-	partNum, err := cg.getPartitionNum(topic)
-	if err != nil || partNum == 0 {
-		return nil, err
-	}
-	consumerList, err := cg.storage.getConsumerList(cg.name)
-	if err != nil {
-		return nil, err
-	}
-	consumerNum := len(consumerList)
-	if consumerNum == 0 {
-		return nil, errors.New("no consumer was found")
-	}
-	partitions := make([]int32, 0, partNum/consumerNum+1)
-	for i := 0; i < partNum; i++ {
-		id := consumerList[i%consumerNum]
-		if id == cg.id {
-			partitions = append(partitions, int32(i))
-		}
-	}
-	return partitions, nil
 }
 
 // CommitOffset is used to commit offset when auto commit was disabled.

--- a/consumer_group.go
+++ b/consumer_group.go
@@ -196,19 +196,19 @@ func (cg *ConsumerGroup) getPartitionConsumer(topic string, partition int32, nex
 }
 
 // GetMessages was used to get a unbuffered message's channel from specified topic
-func (cg *ConsumerGroup) GetMessages(topic string) (<-chan *sarama.ConsumerMessage, error) {
+func (cg *ConsumerGroup) GetMessages(topic string) (<-chan *sarama.ConsumerMessage, bool) {
 	if topicConsumer, ok := cg.topicConsumers[topic]; ok {
-		return topicConsumer.messages, nil
+		return topicConsumer.messages, true
 	}
-	return nil, errors.New("topic was not found")
+	return nil, false
 }
 
 // GetErrors was used to get a unbuffered error's channel from specified topic
-func (cg *ConsumerGroup) GetErrors(topic string) (<-chan *sarama.ConsumerError, error) {
+func (cg *ConsumerGroup) GetErrors(topic string) (<-chan *sarama.ConsumerError, bool) {
 	if topicConsumer, ok := cg.topicConsumers[topic]; ok {
-		return topicConsumer.errors, nil
+		return topicConsumer.errors, true
 	}
-	return nil, errors.New("topic was not found")
+	return nil, false
 }
 
 func (cg *ConsumerGroup) autoReconnect(interval time.Duration) {

--- a/example/example.go
+++ b/example/example.go
@@ -52,12 +52,12 @@ func main() {
 		fmt.Println("Failed to join group, err ", err.Error())
 		os.Exit(1)
 	}
-	messages, err := cg.GetMessages("test")
-	if err != nil {
-		fmt.Println("Failed to get message channel, err", err.Error())
-	}
-	for message := range messages {
-		fmt.Println(string(message.Value), message.Offset)
-		time.Sleep(500 * time.Millisecond)
+	if messages, ok := cg.GetMessages("test"); ok {
+		for message := range messages {
+			fmt.Println(string(message.Value), message.Offset)
+			time.Sleep(500 * time.Millisecond)
+		}
+	} else {
+		fmt.Println("Topic was not found in consumergroup")
 	}
 }

--- a/partition.go
+++ b/partition.go
@@ -1,0 +1,203 @@
+package consumergroup
+
+import (
+	"errors"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"github.com/Shopify/sarama"
+)
+
+type partitionConsumer struct {
+	owner      *topicConsumer
+	group      string
+	topic      string
+	partition  int32
+	offset     int64
+	prevOffset int64
+
+	consumer sarama.PartitionConsumer
+}
+
+func newPartitionConsumer(owner *topicConsumer, partition int32) *partitionConsumer {
+	return &partitionConsumer{
+		owner:      owner,
+		topic:      owner.name,
+		group:      owner.owner.name,
+		partition:  partition,
+		offset:     0,
+		prevOffset: 0,
+	}
+}
+
+func (pc *partitionConsumer) start() {
+	var wg sync.WaitGroup
+
+	cg := pc.owner.owner
+	err := pc.claim()
+	if err != nil {
+		cg.logger.Errorf("Failed to claim topic[%s] partition[%d] and give up, err %s",
+			pc.topic, pc.partition, err)
+		goto ERROR
+	}
+	defer func() {
+		err = pc.release()
+		if err != nil {
+			cg.logger.Errorf("Failed to release topic[%s] partition[%d], err %s",
+				pc.topic, pc.partition, err)
+		} else {
+			cg.logger.Infof("Release topic[%s] partition[%d] success", pc.topic, pc.partition)
+		}
+	}()
+
+	err = pc.loadOffsetFromZk()
+	if err != nil {
+		cg.logger.Errorf("Failed to load topic[%s] partition[%d] offset from zk, err %s",
+			pc.topic, pc.partition, err)
+		goto ERROR
+	}
+	cg.logger.Debugf("Get topic[%s] partition[%d] offset[%d] from offset storage",
+		pc.topic, pc.partition, pc.offset)
+
+	pc.consumer, err = cg.getPartitionConsumer(pc.topic, pc.partition, pc.offset)
+	if err != nil {
+		cg.logger.Errorf("Failed to topic[%s] partition[%d] message, err %s",
+			pc.topic, pc.partition, err)
+		goto ERROR
+	}
+	defer pc.consumer.Close()
+
+	if cg.config.OffsetAutoCommitEnable { // start auto commit-offset thread when enable
+		wg.Add(1)
+		go func() {
+			defer cg.callRecover()
+			defer wg.Done()
+			cg.logger.Infof("Offset auto-commit topic[%s] partition[%d] thread was started",
+				pc.topic, pc.partition)
+			pc.autoCommitOffset()
+		}()
+	}
+
+	pc.fetch()
+	if cg.config.OffsetAutoCommitEnable {
+		err = pc.commitOffset()
+		if err != nil {
+			cg.logger.Errorf("Failed to commit topic[%s] partition[%d] offset",
+				pc.topic, pc.partition, pc.offset)
+		}
+		wg.Wait() // Wait for auto-commit-offset thread
+		cg.logger.Infof("Offset auto-commit topic[%s] partition[%d] thread was stoped",
+			pc.topic, pc.partition)
+	}
+	return
+
+ERROR:
+	cg.ExitGroup()
+}
+
+func (pc *partitionConsumer) loadOffsetFromZk() error {
+	cg := pc.owner.owner
+	offset, err := cg.storage.getOffset(pc.group, pc.topic, pc.partition)
+	if err != nil {
+		return err
+	}
+	if offset == -1 {
+		offset = cg.config.OffsetAutoReset
+	}
+	pc.offset = offset
+	pc.prevOffset = offset
+	return nil
+}
+
+func (pc *partitionConsumer) claim() error {
+	retry := 0
+	cg := pc.owner.owner
+	timer := time.NewTimer(cg.config.ClaimPartitionRetryInterval)
+	defer timer.Stop()
+	for { // retry until claim success or receive the stop signal
+		err := cg.storage.claimPartition(pc.group, pc.topic, pc.partition, cg.id)
+		if err == nil {
+			return nil
+		}
+		if retry%3 == 0 {
+			cg.logger.Errorf("Failed to claim topic[%s] partition[%d] after %d retires, err %s",
+				pc.topic, pc.partition, retry, err)
+		}
+		select {
+		case <-timer.C:
+			retry++
+			timer.Reset(cg.config.ClaimPartitionRetryInterval)
+		case <-cg.stopper:
+			return errors.New("stop signal was received when claim partition")
+		}
+	}
+}
+
+func (pc *partitionConsumer) release() error {
+	cg := pc.owner.owner
+	owner, err := cg.storage.getPartitionOwner(pc.group, pc.topic, pc.partition)
+	if err != nil {
+		return err
+	}
+	if cg.id == owner {
+		return cg.storage.releasePartition(pc.group, pc.topic, pc.partition)
+	}
+	return errors.New("partition wasn't ownered by this consumergroup")
+}
+
+func (pc *partitionConsumer) fetch() {
+	cg := pc.owner.owner
+	messageChan := pc.owner.messages
+	errorChan := pc.owner.errors
+
+PARTITION_CONSUMER_LOOP:
+	for {
+		select {
+		case <-cg.stopper:
+			break PARTITION_CONSUMER_LOOP
+		case err := <-pc.consumer.Errors():
+			errorChan <- err
+		case message := <-pc.consumer.Messages():
+			select {
+			case messageChan <- message:
+				pc.offset++
+			case <-cg.stopper:
+				break PARTITION_CONSUMER_LOOP
+			}
+		}
+	}
+}
+
+func (pc *partitionConsumer) autoCommitOffset() {
+	cg := pc.owner.owner
+	defer cg.callRecover()
+	timer := time.NewTimer(cg.config.OffsetAutoCommitInterval)
+	for {
+		select {
+		case <-cg.stopper:
+			return
+		case <-timer.C:
+			err := pc.commitOffset()
+			if err != nil {
+				cg.logger.Errorf("Failed to auto commit topic[%s] partition[%d] offset[%d], err :%s",
+					pc.topic, pc.partition, pc.offset, err)
+			}
+			timer.Reset(cg.config.OffsetAutoCommitInterval)
+		}
+	}
+}
+
+func (pc *partitionConsumer) commitOffset() error {
+	cg := pc.owner.owner
+	offset := atomic.LoadInt64(&pc.offset)
+	if pc.prevOffset == offset {
+		return nil
+	}
+	err := cg.storage.commitOffset(pc.group, pc.topic, pc.partition, offset)
+	if err != nil {
+		return err
+	}
+	pc.prevOffset = offset
+	return nil
+}

--- a/topic.go
+++ b/topic.go
@@ -1,0 +1,88 @@
+package consumergroup
+
+import (
+	"errors"
+	"sync"
+
+	"github.com/Shopify/sarama"
+)
+
+type topicConsumer struct {
+	group              string
+	name               string
+	owner              *ConsumerGroup
+	errors             chan *sarama.ConsumerError
+	messages           chan *sarama.ConsumerMessage
+	partitionConsumers map[int32]*partitionConsumer
+}
+
+func newTopicConsumer(owner *ConsumerGroup, topic string) *topicConsumer {
+	tc := new(topicConsumer)
+	tc.owner = owner
+	tc.name = topic
+	tc.errors = make(chan *sarama.ConsumerError)
+	tc.messages = make(chan *sarama.ConsumerMessage)
+	return tc
+}
+
+func (tc *topicConsumer) start() {
+	var wg sync.WaitGroup
+
+	cg := tc.owner
+	topic := tc.name
+	cg.logger.Infof("Start to consume topic[%s]", topic)
+	defer cg.logger.Infof("Stop to consume topic[%s]", topic)
+
+	partitions, err := tc.assignPartitions()
+	if err != nil {
+		cg.logger.Errorf("Failed to assign partitions to topic[%s], err %s", topic, err)
+		return
+	}
+	cg.logger.Infof("Topic[%s], partitions %v are assigned to this consumer", topic, partitions)
+	tc.partitionConsumers = make(map[int32]*partitionConsumer)
+	for _, partition := range partitions {
+		tc.partitionConsumers[partition] = newPartitionConsumer(tc, partition)
+	}
+	for partition, consumer := range tc.partitionConsumers {
+		wg.Add(1)
+		go func(pc *partitionConsumer) {
+			defer cg.callRecover()
+			defer wg.Done()
+			pc.start()
+		}(consumer)
+		cg.logger.Infof("Start to consume Topic[%s] partition[%d]", topic, partition)
+	}
+	wg.Wait()
+}
+
+func (tc *topicConsumer) assignPartitions() ([]int32, error) {
+	cg := tc.owner
+	partNum, err := tc.getPartitionNum()
+	if err != nil || partNum == 0 {
+		return nil, err
+	}
+	consumerList, err := cg.storage.getConsumerList(cg.name)
+	if err != nil {
+		return nil, err
+	}
+	consumerNum := len(consumerList)
+	if consumerNum == 0 {
+		return nil, errors.New("no consumer was found")
+	}
+	partitions := make([]int32, 0)
+	for i := int32(0); i < partNum; i++ {
+		id := consumerList[i%int32(consumerNum)]
+		if id == cg.id {
+			partitions = append(partitions, i)
+		}
+	}
+	return partitions, nil
+}
+
+func (tc *topicConsumer) getPartitionNum() (int32, error) {
+	partitions, err := tc.owner.saramaConsumer.Partitions(tc.name)
+	if err != nil {
+		return 0, err
+	}
+	return int32(len(partitions)), nil
+}


### PR DESCRIPTION
* FIX: Fix call recovery should before other defer functions
* MOD: remove unused space
* MOD: remove unnecessary temp var in assign partitions
* Refactor claim partition to retry until consumer group was stopped
* MOD: Refactor consumer-group into topic-consumer and partition-consumer